### PR TITLE
set up defaults for port on merry.listen

### DIFF
--- a/example.js
+++ b/example.js
@@ -12,4 +12,4 @@ app.route('default', function (req, res, ctx) {
   ctx.send(404, { message: 'nada butts here' })
 })
 
-app.listen(8080)
+app.listen()

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ function Merry (opts) {
 
   this.log = pino({ level: opts.logLevel || 'info' }, opts.logStream || process.stdout)
   this.router = serverRouter({ default: '/notFoundHandlerRoute' })
+  this.env = opts.env || {}
   this._port = null
 }
 
@@ -62,10 +63,10 @@ Merry.prototype.start = function () {
 }
 
 Merry.prototype.listen = function (port) {
-  assert.equal(typeof port, 'number', 'Merry.listen: port should be type number')
+  this._port = port || process.env.PORT || this.env.PORT
+  assert.ok(this._port, 'Merry.listen: port should exist')
 
   var server = http.createServer(this.router.start())
-  this._port = port
 
   server.listen(this._port, this.onlisten.bind(this))
 }


### PR DESCRIPTION
fixes #88 with some reasonable defaults and exposes `this.env`