### PR TITLE
fix readme, log, and ctx bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Create a new instance of `merry`. Takes optional opts:
   logging
 - __opts.logStream:__ defaults to `process.stdout`. Set the output writable stream to
   write logs to
+- __opts.logName:__ defaults to `merry`. Sets the name of the logger you're starting
 - __opts.env:__ pass an object containing env var assertions
 
 ### app.route(method, route, handler)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ exports.ENOTFOUND = function (req, res, ctx) {
   ctx.send(404, { 
     type: 'invalid_request_error',
     message: 'Invalid request data'
-  }) 
+  })
 }
 
 exports.EDBOFFLINE  = function (req, res, ctx) {
@@ -146,7 +146,7 @@ exports.EDBOFFLINE  = function (req, res, ctx) {
   ctx.send(500, { 
     type: 'api_error',
     message: 'Internal server error'
-  }) 
+  })
 }
 ```
 
@@ -224,7 +224,6 @@ Create a new instance of `merry`. Takes optional opts:
   logging
 - __opts.logStream:__ defaults to `process.stdout`. Set the output writable stream to
   write logs to
-- __opts.logName:__ defaults to `merry`. Sets the name of the logger you're starting
 - __opts.env:__ pass an object containing env var assertions
 
 ### app.route(method, route, handler)

--- a/README.md
+++ b/README.md
@@ -135,20 +135,18 @@ Merry comes with a recommended pattern to handle errors.
 // errors.js
 exports.ENOTFOUND = function (req, res, ctx) {
   log.warn('ENOTFOUND')
-  res.statusCode = 404
-  return JSON.stringify({
+  ctx.send(404, { 
     type: 'invalid_request_error',
     message: 'Invalid request data'
-  })
+  }) 
 }
 
 exports.EDBOFFLINE  = function (req, res, ctx) {
   log.error('EDBOFFLINE')
-  res.statusCode = 500 
-  return JSON.stringify({
+  ctx.send(500, { 
     type: 'api_error',
     message: 'Internal server error'
-  })
+  }) 
 }
 ```
 

--- a/example.js
+++ b/example.js
@@ -11,6 +11,12 @@ app.route('GET', '/', function (req, res, ctx) {
   ctx.send(200, { cute: 'butts' })
 })
 
+app.route('GET', '/search/:query', function (req, res, ctx) {
+  ctx.log.info('oh hey, a request here')
+  ctx.log.info(ctx.params.query) // logs a :query param
+  ctx.send(200, { cute: 'butts' })
+})
+
 app.route('default', function (req, res, ctx) {
   ctx.log.info('Route doesnt exist')
   ctx.send(404, { message: 'nada butts here' })

--- a/index.js
+++ b/index.js
@@ -15,7 +15,12 @@ function Merry (opts) {
 
   assert.equal(typeof opts, 'object', 'Merry: opts should be type object')
 
-  this.log = pino({ level: opts.logLevel || 'info' }, opts.logStream || process.stdout)
+  var logOpts = {
+    level: opts.logLevel || 'info',
+    name: opts.logName || 'merry'
+  }
+
+  this.log = pino(logOpts, opts.logStream || process.stdout)
   this.router = serverRouter({ default: '/notFoundHandlerRoute' })
   this.env = envobj(opts.env || {})
   this._port = null
@@ -35,7 +40,7 @@ Merry.prototype.route = function (method, route, handler) {
 
   function routeHandler (req, res, params) {
     var ctx = new Ctx(req, res, self.log)
-    ctx.params = params
+    ctx.params = params.params
     handler(req, res, ctx)
   }
 }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@ Merry.prototype.route = function (method, route, handler) {
   assert.equal(typeof route, 'string', 'Merry.route: route should be type string')
 
   var self = this
-  // ease things for V8 by setting handler as prototype
   self.router.route(method, route, routeHandler)
 
   function routeHandler (req, res, params) {
@@ -53,7 +52,7 @@ Merry.prototype.defaultRoute = function (handler) {
 
   function routeHandler (req, res, params) {
     var ctx = new Ctx(req, res, self.log)
-    ctx.params = params
+    ctx.params = params.params
     handler(req, res, ctx)
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "envobj": "^1.0.2",
     "fast-safe-stringify": "^1.1.3",
     "from2-string": "^1.1.0",
+    "log-http": "^1.0.0",
     "pino": "^4.0.0",
     "pino-colada": "^1.4.0",
     "pump": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "deps": "dependency-check . && dependency-check . --extra --no-dev --entry pretty.js",
-    "start": "node example",
+    "start": "node example | ./pretty.js",
     "test": "standard && npm run deps && nyc tap test/*.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
@@ -25,7 +25,7 @@
     "fast-safe-stringify": "^1.1.3",
     "from2-string": "^1.1.0",
     "pino": "^4.0.0",
-    "pino-colada": "^1.0.1",
+    "pino-colada": "^1.4.0",
     "pump": "^1.0.1",
     "server-router": "^5.1.0"
   },
@@ -33,7 +33,6 @@
     "dependency-check": "^2.5.1",
     "dev-null": "^0.1.1",
     "get-server-port": "^1.0.0",
-    "jsonstream": "^1.0.3",
     "nyc": "^10.0.0",
     "request": "^2.79.0",
     "standard": "^8.0.0",


### PR DESCRIPTION
- [x] readme example in errors was a bit off
- [x] `server-router` returns `obj.params` and we need to account for that
- [x] add a logName to logger opts
- [x] there is a bug in the logger output