### PR TITLE
expose env vars on ctx

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ Each route has a signature of `(req, res, ctx)`:
 #### ctx.params
 Parameters picked up from the `router` using the `:route` syntax in the route.
 
+#### ctx.env
+Environment variables passed into the `choo({ env })` constructor.
+
 #### ctx.log[loglevel]\([…data])
 Log data. Loglevel can be one of `trace`, `debug`, `info`, `warn`, `error`,
 `fatal`. Can be passed varying arguments.

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ Merry.prototype.route = function (method, route, handler) {
   self.router.route(method, route, routeHandler)
 
   function routeHandler (req, res, params) {
-    var ctx = new Ctx(req, res, self.log)
+    var ctx = new Ctx(req, res, self)
     ctx.params = params.params
     handler(req, res, ctx)
   }
@@ -105,8 +105,9 @@ Merry.prototype._onerror = function () {
 
 Ctx.prototype.parse = jsonToObject
 
-function Ctx (req, res, log) {
-  this.log = log.child({ parent: 'merry:ctx' })
+function Ctx (req, res, ctx) {
+  this.log = ctx.log.child({ parent: 'merry:ctx' })
+  this.env = ctx.env
   this.req = req
   this.res = res
 }

--- a/test/context.js
+++ b/test/context.js
@@ -30,3 +30,24 @@ tape('context.parse should parse json', function (assert) {
     req.end(JSON.stringify({ foo: 'bar' }))
   })
 })
+
+tape('context.env exposes env vars', function (assert) {
+  assert.plan(3)
+  var env = { FOO: 'bar' }
+  var app = merry({ logStream: devnull(), env: env })
+
+  app.route('GET', '/', function (req, res, ctx) {
+    spok(assert, ctx.env, { FOO: 'bar' })
+    res.end()
+  })
+
+  var server = http.createServer(app.start())
+  server.listen(function () {
+    var uri = 'http://localhost:' + getPort(server) + '/'
+    request.get(uri, function (err, res) {
+      assert.ifError(err, 'no err')
+      assert.equal(res.statusCode, 200, 'status is ok')
+      server.close()
+    })
+  })
+})


### PR DESCRIPTION
Sometimes flags are passed as env vars, this allows route handlers to handle them. Thanks!