### PR TITLE
chore: Test against node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ node_js:
 - "4"
 - "6"
 - "7"
+- "8"
 sudo: false
 language: node_js
 script: "npm run test"


### PR DESCRIPTION
With Node 8 moving into [LTS starting in October 2017](https://github.com/nodejs/LTS), merry should probably be tested against version 8 too.

This pull request simply adds node 8 to the list of versions to test against in travis.