### PR TITLE
Allow response body to be empty string

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ Ctx.prototype.send = function (statusCode, body, headers) {
 
   assert.equal(typeof statusCode, 'number', 'Merry.Ctx.send: statusCode should be type number')
   assert.equal(typeof headers, 'object', 'Merry.Ctx.send: headers should be type object')
-  assert.ok(body, 'Merry.Ctx.send: body should exist')
+  assert.ok(body || body === '', 'Merry.Ctx.send: body should exist')
 
   if (typeof body === 'object') {
     body = stringify(body)


### PR DESCRIPTION
I think an empty string should probably be allowed as a valid response body. Now it gets blocked by an `assert` statement. This patch slightly modifies the assertion to allow an empty string to pass.