### PR TITLE
Fix reference to choo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ Each route has a signature of `(req, res, ctx)`:
 Parameters picked up from the `router` using the `:route` syntax in the route.
 
 #### ctx.env
-Environment variables passed into the `choo({ env })` constructor.
+Environment variables passed into the `merry({ env })` constructor.
 
 #### ctx.log[loglevel]\([…data])
 Log data. Loglevel can be one of `trace`, `debug`, `info`, `warn`, `error`,


### PR DESCRIPTION
Seems like a copy/paste error in the README, where `choo({ env })` is referenced when I assume it should be `merry({ env })`.